### PR TITLE
Fix incorrect "this" use in calculator.model.sample.js

### DIFF
--- a/src/calculator.model.sample.js
+++ b/src/calculator.model.sample.js
@@ -1969,7 +1969,7 @@ var SampleCalc = Backbone.Model.extend({
                 that.StartingSampleConcentrationInNanoMolar /                   // Prep4
                 that.TotalVolumeOfAnnealingReaction;                            // Prep9
 
-            if (!this.nonStandard) {
+            if (!that.nonStandard) {
                 roundedresult = that.gaussianRounding(result, 1);
                 roundedsciar = that.gaussianRounding(that.SampleConcentrationInAnnealingReaction, 1); // Prep??
                 if ((!_.isNaN(result)) && (roundedresult !== roundedsciar)) {


### PR DESCRIPTION
The issue involves Prep20_FinalAnnealedConcentration. Fortunately, because there is a currently a previous check for "that.nonStandard" (and the rest of that check is commented out) and the code then returns if that.nonStandard is true, it looks like the code can currently only reach the point of the incorrect use of "this.nonStandard" if "that.nonStandard" is false. Since any other object like window or a PrepOrderCaller instance probably does not have a "nonStandard" field (which would produce a false result for this.nonStandard), likely this code would still have functioned as expected (as long as the previous check clause remains as-is). It would still be good to fix it though to prevent future issues in case other things change.